### PR TITLE
Create check_all_hai_results.py

### DIFF
--- a/check_all_hai_results.py
+++ b/check_all_hai_results.py
@@ -1,10 +1,7 @@
 import os
 import pandas as pd
 from argparse import ArgumentParser
-import json
-from pathlib import Path
-import glob
-from typing import Iterable, List, Any
+from typing import List, Any
 import boto3
 s3 = boto3.client('s3')
 
@@ -91,11 +88,14 @@ def return_missing(manifest: List, report: List) -> List[Any]:
 if workflow=="phoenix":
     manifest = f"workflow/phoenix/runs/{run}/manifest.csv"
     report = f"workflow/phoenix/runs/{run}/Phoenix_Summary.tsv"
-    s3.download_file(bucket, manifest, f"{run}_manifest.csv")
-    s3.download_file(bucket, report, f"{run}_Phoenix_Summary.tsv")
+    manifest_dl = f"{run}_manifest.csv"
+    report_dl = f"{run}_Phoenix_Summary.tsv"
 
-manifest_df = pd.read_csv(f"{run}_manifest.csv", encoding="utf-8")
-report_df = pd.read_csv(f"{run}_Phoenix_Summary.tsv", sep="\t", encoding="utf-8")
+s3.download_file(bucket, manifest, manifest_dl)
+s3.download_file(bucket, report, report_dl)
+
+manifest_df = pd.read_csv(manifest_dl, encoding="utf-8")
+report_df = pd.read_csv(report_dl, sep="\t", encoding="utf-8")
 
 
 if workflow=="phoenix":
@@ -111,6 +111,6 @@ if missing:
 else:
     print("COMPLETE")
 
-
-
-
+# Clean up
+os.remove(manifest_dl) 
+os.remove(report_dl) 

--- a/check_all_hai_results.py
+++ b/check_all_hai_results.py
@@ -1,0 +1,116 @@
+import os
+import pandas as pd
+from argparse import ArgumentParser
+import json
+from pathlib import Path
+import glob
+from typing import Iterable, List, Any
+import boto3
+s3 = boto3.client('s3')
+
+
+"""
+check_phoenix_run_results.py
+
+Purpose
+-------
+Download a manifest and summary report for a Phoenix workflow run from S3,
+compare the expected sample IDs in the manifest with the IDs present in the
+summary report, and print which samples (if any) are missing.
+
+Requirements
+------------
+- Python 3.7+
+- boto3 installed and configured with credentials that can access the target S3 bucket
+- pandas installed
+
+Behavior
+--------
+- Downloads two objects from S3 (constructed from the provided run name and
+  the 'phoenix' workflow path):
+    workflow/phoenix/runs/{run}/manifest.csv
+    workflow/phoenix/runs/{run}/Phoenix_Summary.tsv
+- Loads the manifest (CSV) and the summary (TSV) into pandas DataFrames.
+- Compares manifest['sample'] to report['ID'] and reports unique manifest
+  values that are not present in the report, preserving the manifest order.
+- Prints "MISSING" followed by missing IDs when there are missing items,
+  otherwise prints "COMPLETE".
+
+Usage
+-----
+From the shell:
+    python check_phoenix_run_results.py --bucket my-bucket --run_name 2025-01-01_run123
+
+Arguments
+---------
+--bucket        (required) S3 bucket name (without "s3://")
+--workflow      (optional) workflow name; default "phoenix" (only phoenix is supported)
+--run_name      (required) run identifier used to build S3 keys and local filenames
+
+Examples
+--------
+# Check run "r001" in bucket "my-bucket"
+python check_phoenix_run_results.py --bucket my-bucket --run_name r001
+
+Notes and safe defaults
+----------------------
+- The script currently only constructs S3 keys for the "phoenix" workflow path.
+  To support other workflows, add their path logic where the manifest/report
+  keys are built.
+- Ensure the AWS credentials used by boto3 have read access to the provided bucket.
+- Local files named "{run}_manifest.csv" and "{run}_Phoenix_Summary.tsv" will be
+  created in the working directory; remove or rotate them if re-running on the
+  same run name to avoid confusion.
+"""
+
+
+parser = ArgumentParser()
+parser.add_argument("--bucket", dest="bk",  default="", help="bucket name (no 's3://')" )
+parser.add_argument("--workflow", dest="wf",  default="phoenix", help="workflow name to check results for" )
+parser.add_argument('--run_name', dest = "run", default=None, help="run name " )
+
+args = parser.parse_args() 
+bucket = args.bk
+workflow = args.wf
+run = args.run
+
+
+def return_missing(manifest: List, report: List) -> List[Any]:
+    """Return unique items from manifest not in report, preserving first-seen order."""
+    report_set = set(report)
+    seen = set()
+    missing: List[Any] = []
+    for m in manifest:
+        if m in report_set or m in seen:
+            continue
+        seen.add(m)
+        missing.append(m)
+    return missing
+
+
+if workflow=="phoenix":
+    manifest = f"workflow/phoenix/runs/{run}/manifest.csv"
+    report = f"workflow/phoenix/runs/{run}/Phoenix_Summary.tsv"
+    s3.download_file(bucket, manifest, f"{run}_manifest.csv")
+    s3.download_file(bucket, report, f"{run}_Phoenix_Summary.tsv")
+
+manifest_df = pd.read_csv(f"{run}_manifest.csv", encoding="utf-8")
+report_df = pd.read_csv(f"{run}_Phoenix_Summary.tsv", sep="\t", encoding="utf-8")
+
+
+if workflow=="phoenix":
+    manifest_ids = manifest_df['sample'].tolist()
+    report_ids = report_df['ID'].tolist()
+
+
+missing = return_missing(manifest_ids, report_ids)
+if missing:
+    print("MISSING")
+    for i in missing:
+        print(i)
+else:
+    print("COMPLETE")
+
+
+
+


### PR DESCRIPTION
Added file check_all_hai_results.py which verifies that all sample ID passed into a workflow have final result, whether that result is passed or failed. 

This is different than the tracker capabilities which shows which seqs are ready for the next processing step based upon filters including "passing" and was created to fill a gap revealed in phoenix v2.2.0-waphl where EC2 failed for some seqs but the final summary was still generated. These seqs were treated similar to failed seqs, although the seqs themselves did not cause the pipeline to fail. 

Currently, this script is only set up to work with phoenix results, but can be expanded at a later point in time to verify results for other workflows.